### PR TITLE
Add refund attribute

### DIFF
--- a/multiversx_sdk_network_providers/contract_results.py
+++ b/multiversx_sdk_network_providers/contract_results.py
@@ -38,6 +38,7 @@ class ContractResultItem:
         self.gas_price: int = 0
         self.call_type: int = 0
         self.return_message: str = ""
+        self.is_refund: bool = False
         self.logs: TransactionLogs = TransactionLogs()
     
     def to_dictionary(self) -> Dict[str, Any]:
@@ -92,6 +93,7 @@ class ContractResultItem:
         item.data = response.get("data", "")
         item.call_type = response.get("callType", 0)
         item.return_message = response.get("returnMessage", "")
+        item.is_refund = response.get("isRefund", False)
 
         item.logs = TransactionLogs.from_http_response(response.get("logs", {}))
 

--- a/multiversx_sdk_network_providers/proxy_network_provider_test.py
+++ b/multiversx_sdk_network_providers/proxy_network_provider_test.py
@@ -109,6 +109,7 @@ class TestProxy:
         assert result.is_completed == True
         assert len(result.contract_results.items) > 0
         assert result.data == 'issue@54455354@54455354@03e8@00@63616e4d696e74@74727565@63616e4275726e@74727565@63616e4368616e67654f776e6572@74727565@63616e55706772616465@74727565'
+        assert sum([r.is_refund for r in result.contract_results.items]) == 1
     
     def test_get_hyperblock(self):
         result_by_nonce = self.proxy.get_hyperblock(4199287)


### PR DESCRIPTION
I propose to add the attribute `is_refund` to the class `ContractResultItem`.
This would be useful to differentiate eGLD transfers from gas refund when inspecting the smart contract results.

I looked into the previous PRs of this repo and concluded that I should not change the package version for this change. Please correct me if I'm wrong.

For the context, I'm developping a [devops package](https://github.com/Catenscia/MxOps) for MultiversX contract and this feature would be extremely useful. (At the moment, I see no way of differentiating refunds from egld transfers)