### PR TITLE
Fix send transaction for the API Provider

### DIFF
--- a/multiversx_sdk_network_providers/api_network_provider.py
+++ b/multiversx_sdk_network_providers/api_network_provider.py
@@ -10,7 +10,7 @@ from multiversx_sdk_network_providers.contract_query_requests import ContractQue
 from multiversx_sdk_network_providers.contract_query_response import ContractQueryResponse
 from multiversx_sdk_network_providers.errors import GenericError
 from multiversx_sdk_network_providers.interface import (IAddress, IContractQuery, IPagination,
-                                     ITransaction)
+                                                        ITransaction)
 from multiversx_sdk_network_providers.network_config import NetworkConfig
 from multiversx_sdk_network_providers.network_general_statistics import NetworkGeneralStatistics
 from multiversx_sdk_network_providers.network_stake import NetworkStake
@@ -19,7 +19,7 @@ from multiversx_sdk_network_providers.proxy_network_provider import ProxyNetwork
 from multiversx_sdk_network_providers.token_definitions import (
     DefinitionOfFungibleTokenOnNetwork, DefinitionOfTokenCollectionOnNetwork)
 from multiversx_sdk_network_providers.tokens import (FungibleTokenOfAccountOnNetwork,
-                                  NonFungibleTokenOfAccountOnNetwork)
+                                                     NonFungibleTokenOfAccountOnNetwork)
 from multiversx_sdk_network_providers.transaction_status import TransactionStatus
 from multiversx_sdk_network_providers.transactions import TransactionOnNetwork
 from multiversx_sdk_network_providers.utils import decimal_to_padded_hex
@@ -114,7 +114,7 @@ class ApiNetworkProvider:
         transaction = TransactionOnNetwork.from_api_http_response(tx_hash, response)
 
         return transaction
-    
+
     def get_transactions(self, address: IAddress, pagination: IPagination = DefaultPagination()) -> List[TransactionOnNetwork]:
         url = f"accounts/{address.bech32()}/transactions?{self._build_pagination_params(pagination)}"
         response = self.do_get_generic_collection(url)
@@ -130,7 +130,7 @@ class ApiNetworkProvider:
         return status
 
     def send_transaction(self, transaction: ITransaction) -> str:
-        url = f'{self.url}/transactions'
+        url = f'transactions'
         response = self.do_post_generic(url, transaction.to_dictionary())
         tx_hash: str = response.get('txHash', '')
 

--- a/multiversx_sdk_network_providers/api_network_provider_test.py
+++ b/multiversx_sdk_network_providers/api_network_provider_test.py
@@ -1,6 +1,7 @@
 import pytest
-from multiversx_sdk_core import Address
+from typing import Any, Dict
 
+from multiversx_sdk_core import Address
 from multiversx_sdk_network_providers.api_network_provider import ApiNetworkProvider
 from multiversx_sdk_network_providers.errors import GenericError
 from multiversx_sdk_network_providers.proxy_network_provider import ContractQuery
@@ -11,10 +12,10 @@ class Pagination(IPagination):
     def __init__(self, start: int, size: int) -> None:
         self.start = start
         self.size = size
-    
+
     def get_start(self) -> int:
         return self.start
-    
+
     def get_size(self) -> int:
         return self.size
 
@@ -87,7 +88,7 @@ class TestApi:
         assert result.sender.bech32() == 'erd1testnlersh4z0wsv8kjx39me4rmnvjkwu8dsaea7ukdvvc9z396qykv7z7'
         assert result.receiver.bech32() == 'erd1c8tnzykaj7lhrd5cy6jap533afr4dqu7uqcdm6qv4wuwly9lcsqqm9ll4f'
         assert result.value == '10000000000000000000'
-    
+
     def test_get_transactions(self):
         address = Address.from_bech32('erd1testnlersh4z0wsv8kjx39me4rmnvjkwu8dsaea7ukdvvc9z396qykv7z7')
         pagination = Pagination(0, 2)
@@ -146,3 +147,32 @@ class TestApi:
         assert result.balance == 0
         assert result.royalties != 0
         assert result.timestamp != 0
+
+    def test_send_transaction(self):
+        transaction = DummyTransaction(
+            {
+                "nonce": 42,
+                "value": "1",
+                "receiver": "erd1testnlersh4z0wsv8kjx39me4rmnvjkwu8dsaea7ukdvvc9z396qykv7z7",
+                "sender": "erd15x2panzqvfxul2lvstfrmdcl5t4frnsylfrhng8uunwdssxw4y9succ9sq",
+                "gasPrice": 1000000000,
+                "gasLimit": 50000,
+                "chainID": "D",
+                "version": 1,
+                "signature": "c8eb539e486db7d703d8c70cab3b7679113f77c4685d8fcc94db027ceacc6b8605115034355386dffd7aa12e63dbefa03251a2f1b1d971f52250187298d12900",
+            }
+        )
+
+        expected_hash = (
+            "6e2fa63ea02937f00d7549f3e4eb9af241e4ac13027aa65a5300816163626c01"
+        )
+
+        assert self.api.send_transaction(transaction) == expected_hash
+
+
+class DummyTransaction:
+    def __init__(self, transaction: Dict[str, Any]) -> None:
+        self.transaction = transaction
+
+    def to_dictionary(self) -> Dict[str, Any]:
+        return self.transaction

--- a/multiversx_sdk_network_providers/transactions.py
+++ b/multiversx_sdk_network_providers/transactions.py
@@ -7,7 +7,9 @@ from multiversx_sdk_network_providers.contract_results import ContractResults
 from multiversx_sdk_network_providers.interface import IAddress
 from multiversx_sdk_network_providers.resources import EmptyAddress
 from multiversx_sdk_network_providers.transaction_completion_strategy import (
-    TransactionCompletionStrategyOnApi, TransactionCompletionStrategyOnProxy)
+    TransactionCompletionStrategyOnApi,
+    TransactionCompletionStrategyOnProxy,
+)
 from multiversx_sdk_network_providers.transaction_logs import TransactionLogs
 from multiversx_sdk_network_providers.transaction_receipt import TransactionReceipt
 from multiversx_sdk_network_providers.transaction_status import TransactionStatus
@@ -16,8 +18,8 @@ from multiversx_sdk_network_providers.transaction_status import TransactionStatu
 class TransactionOnNetwork:
     def __init__(self):
         self.is_completed: bool = False
-        self.hash: str = ''
-        self.type: str = ''
+        self.hash: str = ""
+        self.type: str = ""
         self.nonce: int = 0
         self.round: int = 0
         self.epoch: int = 0
@@ -26,14 +28,14 @@ class TransactionOnNetwork:
         self.sender: IAddress = EmptyAddress()
         self.gas_limit: int = 0
         self.gas_price: int = 0
-        self.data: str = ''
-        self.signature: str = ''
+        self.data: str = ""
+        self.signature: str = ""
         self.status: TransactionStatus = TransactionStatus()
         self.timestamp: int = 0
 
         self.block_nonce: int = 0
         self.hyperblock_nonce: int = 0
-        self.hyperblock_hash: str = ''
+        self.hyperblock_hash: str = ""
 
         self.receipt: TransactionReceipt = TransactionReceipt()
         self.contract_results: ContractResults = ContractResults([])
@@ -43,54 +45,68 @@ class TransactionOnNetwork:
         return self.status
 
     @staticmethod
-    def from_api_http_response(tx_hash: str, response: Dict[str, Any]) -> 'TransactionOnNetwork':
+    def from_api_http_response(
+        tx_hash: str, response: Dict[str, Any]
+    ) -> "TransactionOnNetwork":
         result = TransactionOnNetwork.from_http_response(tx_hash, response)
-        result.contract_results = ContractResults.from_api_http_response(response.get('results', []))
+        result.contract_results = ContractResults.from_api_http_response(
+            response.get("results", [])
+        )
         result.is_completed = TransactionCompletionStrategyOnApi().is_completed(result)
 
         return result
 
     @staticmethod
-    def from_proxy_http_response(tx_hash: str, response: Dict[str, Any]) -> 'TransactionOnNetwork':
+    def from_proxy_http_response(
+        tx_hash: str, response: Dict[str, Any]
+    ) -> "TransactionOnNetwork":
         result = TransactionOnNetwork.from_http_response(tx_hash, response)
 
-        result.contract_results = ContractResults.from_proxy_http_response(response.get('smartContractResults', []))
-        result.is_completed = TransactionCompletionStrategyOnProxy().is_completed(result)
+        result.contract_results = ContractResults.from_proxy_http_response(
+            response.get("smartContractResults", [])
+        )
+        result.is_completed = TransactionCompletionStrategyOnProxy().is_completed(
+            result
+        )
 
         return result
 
     @staticmethod
-    def from_http_response(tx_hash: str, response: Dict[str, Any]) -> 'TransactionOnNetwork':
+    def from_http_response(
+        tx_hash: str, response: Dict[str, Any]
+    ) -> "TransactionOnNetwork":
         result = TransactionOnNetwork()
 
         result.hash = tx_hash
-        result.type = response.get('type', '')
-        result.nonce = response.get('nonce', 0)
-        result.round = response.get('round', 0)
-        result.epoch = response.get('epoch', 0)
-        result.value = response.get('value', 0)
+        result.type = response.get("type", "")
+        result.nonce = response.get("nonce", 0)
+        result.round = response.get("round", 0)
+        result.epoch = response.get("epoch", 0)
+        result.value = response.get("value", 0)
 
-        sender = response.get('sender', '')
+        sender = response.get("sender", "")
         result.sender = Address.from_bech32(sender) if sender else EmptyAddress()
 
-        receiver = response.get('receiver', '')
+        receiver = response.get("receiver", "")
         result.receiver = Address.from_bech32(receiver) if receiver else EmptyAddress()
 
-        result.gas_price = response.get('gasPrice', 0)
-        result.gas_limit = response.get('gasLimit', 0)
+        result.gas_price = response.get("gasPrice", 0)
+        result.gas_limit = response.get("gasLimit", 0)
 
-        data = response.get('data', '') or ""
+        data = response.get("data", "") or ""
 
         result.data = base64.b64decode(data).decode()
-        result.status = TransactionStatus(response.get('status'))
-        result.timestamp = response.get('timestamp', 0)
+        result.status = TransactionStatus(response.get("status"))
+        result.timestamp = response.get("timestamp", 0)
 
-        result.block_nonce = response.get('blockNonce', 0)
-        result.hyperblock_nonce = response.get('hyperblockNonce', 0)
-        result.hyperblock_hash = response.get('hyperblockHash', '')
+        result.block_nonce = response.get("blockNonce", 0)
+        result.hyperblock_nonce = response.get("hyperblockNonce", 0)
+        result.hyperblock_hash = response.get("hyperblockHash", "")
 
-        result.receipt = TransactionReceipt.from_http_response(response.get('receipt', {}))
-        result.logs = TransactionLogs.from_http_response(response.get('logs', {}))
+        result.receipt = TransactionReceipt.from_http_response(
+            response.get("receipt", {})
+        )
+        result.logs = TransactionLogs.from_http_response(response.get("logs", {}))
 
         return result
 
@@ -113,5 +129,5 @@ class TransactionOnNetwork:
             "timestamp": self.timestamp,
             "blockNonce": self.block_nonce,
             "hyperblockNonce": self.hyperblock_nonce,
-            "hyperblockHash": self.hyperblock_hash
+            "hyperblockHash": self.hyperblock_hash,
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ allow-direct-references = true
 
 [project]
 name = "multiversx-sdk-network-providers"
-version = "0.6.6"
+version = "0.6.7"
 authors = [
   { name="MultiversX" },
 ]


### PR DESCRIPTION
The `send_transaction` endpoint used to concatenate the API url with the specific route for sending transactions and the same thing would have been done in the `do_post_generic` function, thus an error would occur.

Also added a test for the endpoint, the same that is used for the proxy. 