### PR TITLE
Add SC Results and Logs for tx `to_dictionary` method

### DIFF
--- a/multiversx_sdk_network_providers/proxy_network_provider.py
+++ b/multiversx_sdk_network_providers/proxy_network_provider.py
@@ -5,7 +5,7 @@ from requests.auth import AuthBase
 
 from multiversx_sdk_network_providers.accounts import AccountOnNetwork
 from multiversx_sdk_network_providers.constants import (DEFAULT_ADDRESS_HRP,
-                                     ESDT_CONTRACT_ADDRESS, METACHAIN_ID)
+                                                        ESDT_CONTRACT_ADDRESS, METACHAIN_ID)
 from multiversx_sdk_network_providers.contract_query_requests import ContractQueryRequest
 from multiversx_sdk_network_providers.contract_query_response import ContractQueryResponse
 from multiversx_sdk_network_providers.errors import GenericError
@@ -16,7 +16,7 @@ from multiversx_sdk_network_providers.resources import GenericResponse, Simulate
 from multiversx_sdk_network_providers.token_definitions import (
     DefinitionOfFungibleTokenOnNetwork, DefinitionOfTokenCollectionOnNetwork)
 from multiversx_sdk_network_providers.tokens import (FungibleTokenOfAccountOnNetwork,
-                                  NonFungibleTokenOfAccountOnNetwork)
+                                                     NonFungibleTokenOfAccountOnNetwork)
 from multiversx_sdk_network_providers.transaction_status import TransactionStatus
 from multiversx_sdk_network_providers.transactions import TransactionOnNetwork
 
@@ -81,7 +81,7 @@ class ProxyNetworkProvider:
         transaction = TransactionOnNetwork.from_proxy_http_response(tx_hash, response)
 
         return transaction
-    
+
     def get_account_transactions(self, address: IAddress) -> List[TransactionOnNetwork]:
         url = f"address/{address.bech32()}/transactions"
         response = self.do_get_generic(url).get("transactions", [])
@@ -135,12 +135,12 @@ class ProxyNetworkProvider:
         definition = DefinitionOfTokenCollectionOnNetwork.from_response_of_get_token_properties(collection, properties, self.address_hrp)
 
         return definition
-    
+
     def simulate_transaction(self, transaction: ITransaction) -> SimulateResponse:
         url = "transaction/simulate"
         response = self.do_post_generic(url, transaction.to_dictionary())
         return SimulateResponse(response)
-    
+
     def get_hyperblock(self, key: Union[int, str]) -> Dict[str, Any]:
         url = f"hyperblock/by-hash/{key}"
         if str(key).isnumeric():
@@ -227,3 +227,8 @@ class ContractQuery(IContractQuery):
 
     def get_value(self) -> int:
         return self.value
+
+
+proxy = ProxyNetworkProvider("https://devnet-gateway.multiversx.com")
+tx = proxy.get_transaction("b9d2ef81e9d170aed61394d94225b4991892f70c96b4b1be32a7ccc04696dd0c")
+print(tx.to_dictionary())

--- a/multiversx_sdk_network_providers/proxy_network_provider.py
+++ b/multiversx_sdk_network_providers/proxy_network_provider.py
@@ -227,8 +227,3 @@ class ContractQuery(IContractQuery):
 
     def get_value(self) -> int:
         return self.value
-
-
-proxy = ProxyNetworkProvider("https://devnet-gateway.multiversx.com")
-tx = proxy.get_transaction("b9d2ef81e9d170aed61394d94225b4991892f70c96b4b1be32a7ccc04696dd0c")
-print(tx.to_dictionary())

--- a/multiversx_sdk_network_providers/transaction_events.py
+++ b/multiversx_sdk_network_providers/transaction_events.py
@@ -32,7 +32,7 @@ class TransactionEvent:
         return {
             "address": self.address.bech32(),
             "identifier": self.identifier,
-            "topics": [item.__str__() for item in self.topics],
+            "topics": [item.hex() for item in self.topics],
             "data": self.data
         }
 

--- a/multiversx_sdk_network_providers/transaction_events.py
+++ b/multiversx_sdk_network_providers/transaction_events.py
@@ -28,13 +28,21 @@ class TransactionEvent:
 
         return result
 
+    def to_dictionary(self) -> Dict[str, Any]:
+        return {
+            "address": self.address.bech32(),
+            "identifier": self.identifier,
+            "topics": [item.__str__() for item in self.topics],
+            "data": self.data
+        }
+
 
 class TransactionEventTopic:
     def __init__(self, topic: str):
         self.raw = base64.b64decode(topic.encode())
 
     def __str__(self):
-        return self.raw.decode()
+        return base64.b64encode(self.raw).decode()
 
     def hex(self):
         return self.raw.hex()

--- a/multiversx_sdk_network_providers/transaction_events.py
+++ b/multiversx_sdk_network_providers/transaction_events.py
@@ -32,7 +32,7 @@ class TransactionEvent:
         return {
             "address": self.address.bech32(),
             "identifier": self.identifier,
-            "topics": [item.hex() for item in self.topics],
+            "topics": [item.__str__() for item in self.topics],
             "data": self.data
         }
 

--- a/multiversx_sdk_network_providers/transaction_logs.py
+++ b/multiversx_sdk_network_providers/transaction_logs.py
@@ -37,3 +37,9 @@ class TransactionLogs:
             events = list(filter(predicate, events))
 
         return events
+
+    def to_dictionary(self) -> Dict[str, Any]:
+        return {
+            "address": self.address.bech32(),
+            "events": [item.to_dictionary() for item in self.events]
+        }

--- a/multiversx_sdk_network_providers/transactions.py
+++ b/multiversx_sdk_network_providers/transactions.py
@@ -130,4 +130,6 @@ class TransactionOnNetwork:
             "blockNonce": self.block_nonce,
             "hyperblockNonce": self.hyperblock_nonce,
             "hyperblockHash": self.hyperblock_hash,
+            "smartContractResults": [item.to_dictionary() for item in self.contract_results.items],
+            "logs": self.logs.to_dictionary(),
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ allow-direct-references = true
 
 [project]
 name = "multiversx-sdk-network-providers"
-version = "0.6.7"
+version = "0.6.8"
 authors = [
   { name="MultiversX" },
 ]


### PR DESCRIPTION
Somebody from the community mentioned that when using `mxpy` to get a transaction with the flag `--with-results` no SC Results and Logs were displayed because the `Transaction.to_dictionary()` method did not have these fields. Fixed in this PR.