### PR TITLE
Hex encode transaction topic in `to_dictionary()`

### DIFF
--- a/multiversx_sdk_network_providers/api_network_provider_test.py
+++ b/multiversx_sdk_network_providers/api_network_provider_test.py
@@ -143,7 +143,7 @@ class TestApi:
 
         assert result.identifier == 'ABC-10df96'
         assert result.owner.bech32() == 'erd1testnlersh4z0wsv8kjx39me4rmnvjkwu8dsaea7ukdvvc9z396qykv7z7'
-        assert not result.can_upgrade
+        assert result.can_upgrade
         assert not result.can_freeze
         assert result.decimals == 1
         assert result.supply == 5

--- a/multiversx_sdk_network_providers/transaction_events.py
+++ b/multiversx_sdk_network_providers/transaction_events.py
@@ -8,7 +8,7 @@ from multiversx_sdk_network_providers.resources import EmptyAddress
 
 
 class TransactionEvent:
-    def __init__(self):
+    def __init__(self) -> None:
         self.address: IAddress = EmptyAddress()
         self.identifier: str = ''
         self.topics: List[TransactionEventTopic] = []
@@ -32,17 +32,17 @@ class TransactionEvent:
         return {
             "address": self.address.bech32(),
             "identifier": self.identifier,
-            "topics": [item.__str__() for item in self.topics],
+            "topics": [item.hex() for item in self.topics],
             "data": self.data
         }
 
 
 class TransactionEventTopic:
-    def __init__(self, topic: str):
+    def __init__(self, topic: str) -> None:
         self.raw = base64.b64decode(topic.encode())
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.raw.decode()
 
-    def hex(self):
+    def hex(self) -> str:
         return self.raw.hex()


### PR DESCRIPTION
In the `to_dictionary()` method from the `TransactionEvent` class the `topic` was converted to a `string` and that could result in an error. It's now converted to `hex()`.