### PR TITLE
Fix return type adnotation for send-transactions

### DIFF
--- a/multiversx_sdk_network_providers/api_network_provider.py
+++ b/multiversx_sdk_network_providers/api_network_provider.py
@@ -162,7 +162,7 @@ class ApiNetworkProvider:
         tx_hash: str = response.get('txHash', '')
         return tx_hash
 
-    def send_transactions(self, transactions: List[ITransactionDto]) -> Tuple[int, str]:
+    def send_transactions(self, transactions: List[ITransactionDto]) -> Tuple[int, Dict[str, str]]:
         response = self.backing_proxy.send_transactions(transactions)
         return response
 

--- a/multiversx_sdk_network_providers/proxy_network_provider.py
+++ b/multiversx_sdk_network_providers/proxy_network_provider.py
@@ -115,7 +115,7 @@ class ProxyNetworkProvider:
         response = self.do_post_generic('transaction/send', transaction_to_dictionary(transaction))
         return response.get('txHash', '')
 
-    def send_transactions(self, transactions: Sequence[ITransactionDto]) -> Tuple[int, str]:
+    def send_transactions(self, transactions: Sequence[ITransactionDto]) -> Tuple[int, Dict[str, str]]:
         transactions_as_dictionaries = [transaction_to_dictionary(transaction) for transaction in transactions]
         response = self.do_post_generic('transaction/send-multiple', transactions_as_dictionaries)
         # Proxy and Observers have different response format:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ allow-direct-references = true
 
 [project]
 name = "multiversx-sdk-network-providers"
-version = "0.12.1"
+version = "0.12.2"
 authors = [
   { name="MultiversX" },
 ]


### PR DESCRIPTION
The `send_transactions()` method used to specify that the return value is `Tuple[int, str]` while it returned something of type `Tuple[int, Dict[str, str]]`. Changed the return type to specify the correct value.